### PR TITLE
third example of group aesthetic with geom_smooth(): linetype instead group

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -359,7 +359,7 @@ ggplot(data = mpg) +
     
 ggplot(data = mpg) +
   geom_smooth(
-    mapping = aes(x = displ, y = hwy, group = drv)
+    mapping = aes(x = displ, y = hwy, linetype = drv)
   )
 ```
 


### PR DESCRIPTION
Second and third example of `group` aesthetic with the `geom_smooth()` function are identical. It seems to me that the third example should refer to the mapping of an aesthetic to a discrete variable (as in the `linetype` example) in order to demonstrate that a legend will be produced automatically.

(Sorry if I understood or did something wrong. I am a newcomer to R and this is my first pull request in my life… But I very much enjoy your book!)